### PR TITLE
Fix the case when `SDWebImageFirstFrameOnly` hit memory cache, the animated image still been provided

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Expecta (1.0.6)
-  - SDWebImage/Core (5.0.0)
+  - SDWebImage/Core (5.0.2)
   - SDWebImageYYPlugin (0.2.0):
     - SDWebImage/Core (~> 5.0)
     - SDWebImageYYPlugin/YYCache (= 0.2.0)
@@ -34,7 +34,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
-  SDWebImage: 5de80a0302de9e377e62f47d2fa1304efff0e55f
+  SDWebImage: 6764b5fa0f73c203728052955dbefa2bf1f33282
   SDWebImageYYPlugin: 3398b1f1016cd30d8fdb857226c254a0da8b1a11
   YYCache: 8105b6638f5e849296c71f331ff83891a4942952
   YYImage: 1e1b62a9997399593e4b9c4ecfbbabbf1d3f3b54

--- a/SDWebImageYYPlugin/Classes/YYCache/YYCacheBridge/YYCache+SDAdditions.m
+++ b/SDWebImageYYPlugin/Classes/YYCache/YYCacheBridge/YYCache+SDAdditions.m
@@ -45,6 +45,15 @@ static NSData * SDYYPluginCacheDataWithImageData(UIImage *image, NSData *imageDa
     
     // First check the in-memory cache...
     UIImage *image = [self.memoryCache objectForKey:key];
+    
+    if ((options & SDImageCacheDecodeFirstFrameOnly) && image.sd_isAnimated) {
+#if SD_MAC
+        image = [[NSImage alloc] initWithCGImage:image.CGImage scale:image.scale orientation:kCGImagePropertyOrientationUp];
+#else
+        image = [[UIImage alloc] initWithCGImage:image.CGImage scale:image.scale orientation:image.imageOrientation];
+#endif
+    }
+    
     BOOL shouldQueryMemoryOnly = (image && !(options & SDImageCacheQueryMemoryData));
     if (shouldQueryMemoryOnly) {
         if (doneBlock) {


### PR DESCRIPTION
See https://github.com/SDWebImage/SDWebImage/pull/2725