### PR TITLE
Override the UIImage+Metadata category method to provide the correct value for YYImage

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "SDWebImage/SDWebImage" ~> 5.4
+github "SDWebImage/SDWebImage" ~> 5.6
 github "ibireme/YYCache" ~> 1.0
 github "ibireme/YYImage" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "SDWebImage/SDWebImage" "5.4.0"
+github "SDWebImage/SDWebImage" "5.6.0"
 github "ibireme/YYCache" "1.0.4"
 github "ibireme/YYImage" "1.0.4"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Expecta (1.0.6)
-  - SDWebImage/Core (5.4.0)
+  - SDWebImage/Core (5.6.0)
   - SDWebImageYYPlugin (0.3.0):
     - SDWebImage/Core (~> 5.4)
     - SDWebImageYYPlugin/YYCache (= 0.3.0)
@@ -34,7 +34,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
-  SDWebImage: 5bf6aec6481ae2a062bdc59f9d6c1d1e552090e0
+  SDWebImage: 21b19f56b4226cdfe3aefe4e6848dc43ed129a86
   SDWebImageYYPlugin: f6c1af162fb075efe5918d8caedee1f3d17c197e
   YYCache: 8105b6638f5e849296c71f331ff83891a4942952
   YYImage: 1e1b62a9997399593e4b9c4ecfbbabbf1d3f3b54

--- a/SDWebImageYYPlugin.podspec
+++ b/SDWebImageYYPlugin.podspec
@@ -31,7 +31,7 @@ TODO: Add long description of the pod here.
   s.source_files = 'SDWebImageYYPlugin/Module/SDWebImageYYPlugin.h'
   s.module_map = 'SDWebImageYYPlugin/Module/SDWebImageYYPlugin.modulemap'
 
-  s.dependency 'SDWebImage/Core', '~> 5.4'
+  s.dependency 'SDWebImage/Core', '~> 5.6'
 
   s.subspec 'YYCache' do |ss|
     ss.dependency 'YYCache'

--- a/SDWebImageYYPlugin/Classes/YYImage/YYImageBridge/YYImage+SDAdditions.m
+++ b/SDWebImageYYPlugin/Classes/YYImage/YYImageBridge/YYImage+SDAdditions.m
@@ -65,3 +65,44 @@
 
 @end
 
+@implementation YYImage (Metadata)
+
+- (BOOL)sd_isAnimated {
+    return YES;
+}
+
+- (NSUInteger)sd_imageLoopCount {
+    return self.animatedImageLoopCount;
+}
+
+- (void)setSd_imageLoopCount:(NSUInteger)sd_imageLoopCount {
+    return;
+}
+
+- (SDImageFormat)sd_imageFormat {
+    switch (self.animatedImageType) {
+        case YYImageTypeJPEG:
+        case YYImageTypeJPEG2000:
+            return SDImageFormatJPEG;
+        case YYImageTypePNG:
+            return SDImageFormatPNG;
+        case YYImageTypeGIF:
+            return SDImageFormatGIF;
+        case YYImageTypeTIFF:
+            return SDImageFormatTIFF;
+        case YYImageTypeWebP:
+            return SDImageFormatWebP;
+        default:
+            return SDImageFormatUndefined;
+    }
+}
+
+- (void)setSd_imageFormat:(SDImageFormat)sd_imageFormat {
+    return;
+}
+
+- (BOOL)sd_isVector {
+    return NO;
+}
+
+@end


### PR DESCRIPTION
This match 5.6.0 SDAnimatedImage behavior