### PR TITLE
Bump the support for SDWebImage 5.15.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "SDWebImage/SDWebImage" ~> 5.10
+github "SDWebImage/SDWebImage" ~> 5.15
 github "ibireme/YYCache" ~> 1.0
 github "ibireme/YYImage" ~> 1.0

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
   - Expecta (1.0.6)
-  - SDWebImage/Core (5.10.3)
-  - SDWebImageYYPlugin (0.6.0):
-    - SDWebImage/Core (~> 5.10)
-    - SDWebImageYYPlugin/YYCache (= 0.6.0)
-    - SDWebImageYYPlugin/YYImage (= 0.6.0)
-  - SDWebImageYYPlugin/YYCache (0.6.0):
-    - SDWebImage/Core (~> 5.10)
+  - SDWebImage/Core (5.15.0)
+  - SDWebImageYYPlugin (0.7.0):
+    - SDWebImage/Core (~> 5.15)
+    - SDWebImageYYPlugin/YYCache (= 0.7.0)
+    - SDWebImageYYPlugin/YYImage (= 0.7.0)
+  - SDWebImageYYPlugin/YYCache (0.7.0):
+    - SDWebImage/Core (~> 5.15)
     - YYCache
-  - SDWebImageYYPlugin/YYImage (0.6.0):
-    - SDWebImage/Core (~> 5.10)
+  - SDWebImageYYPlugin/YYImage (0.7.0):
+    - SDWebImage/Core (~> 5.15)
     - YYImage/Core
   - YYCache (1.0.4)
   - YYImage/Core (1.0.4)
@@ -34,11 +34,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
-  SDWebImage: e378178472b735e84b007bfb55514c97948a0598
-  SDWebImageYYPlugin: 44e88320fc9604b6abb09d8271504bdd986dcf2e
+  SDWebImage: 9bec4c5cdd9579e1f57104735ee0c37df274d593
+  SDWebImageYYPlugin: 9ff87103cef7b39ac608303d756f1ce9899b9012
   YYCache: 8105b6638f5e849296c71f331ff83891a4942952
   YYImage: 1e1b62a9997399593e4b9c4ecfbbabbf1d3f3b54
 
 PODFILE CHECKSUM: 71679fe963dea37bf4e76ca762d8b118854ce524
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.11.3

--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/SDWebImage/SDWebImageYYPlugin)
 [![codecov](https://codecov.io/gh/SDWebImage/SDWebImageYYPlugin/branch/master/graph/badge.svg)](https://codecov.io/gh/SDWebImage/SDWebImageYYPlugin)
 
-
 ## What's for
 SDWebImageYYPlugin is a plugin for [SDWebImage](https://github.com/rs/SDWebImage/) framework, which provide the image loading support for [YYImage](https://github.com/ibireme/YYImage) (including YYImage's decoding system and `YYAnimatedImageView`) and [YYCache](https://github.com/ibireme/YYCache) cache system.
 
 By using SDWebImageYYPlugin, you can use all you familiar SDWebImage's loading method, on the `YYAnimatedImageView`.
 
 And you can also use `YYCache` instead of `SDImageCache` for image cache system, which may better memory cache performance (By taking advanced of LRU algorithm), and disk cache performance (By taking advanced of sqlite blob storage)
+
+## Long term maintenance
+This repo was created as a showcase how power the SDWebImage 5.0's customization can be. But actually is not recommended to use in commercial applications.
+
+Since the upstream YYImage/YYCache has no longer maintained, and SDWebImage itself has become more and more performant than previous versions. I will not always up-to-date the compatibility with SDWebImage's internal changes from version to version. This repo will be deprecated in the future (like SDWebImage 6.0). But the PR for bugfix is still welcomed.
 
 ## Usage
 

--- a/SDWebImageYYPlugin.podspec
+++ b/SDWebImageYYPlugin.podspec
@@ -31,7 +31,7 @@ TODO: Add long description of the pod here.
   s.source_files = 'SDWebImageYYPlugin/Module/SDWebImageYYPlugin.h'
   s.module_map = 'SDWebImageYYPlugin/Module/SDWebImageYYPlugin.modulemap'
 
-  s.dependency 'SDWebImage/Core', '~> 5.10'
+  s.dependency 'SDWebImage/Core', '~> 5.15'
 
   s.subspec 'YYCache' do |ss|
     ss.dependency 'YYCache'

--- a/SDWebImageYYPlugin/Classes/YYImage/YYImageBridge/YYImage+SDAdditions.m
+++ b/SDWebImageYYPlugin/Classes/YYImage/YYImageBridge/YYImage+SDAdditions.m
@@ -8,6 +8,24 @@
 #import "YYImage+SDAdditions.h"
 #import <objc/runtime.h>
 
+static inline SDImageFormat SDImageFormatFromYYImageType(YYImageType type) {
+    switch (type) {
+        case YYImageTypeJPEG:
+        case YYImageTypeJPEG2000:
+            return SDImageFormatJPEG;
+        case YYImageTypePNG:
+            return SDImageFormatPNG;
+        case YYImageTypeGIF:
+            return SDImageFormatGIF;
+        case YYImageTypeTIFF:
+            return SDImageFormatTIFF;
+        case YYImageTypeWebP:
+            return SDImageFormatWebP;
+        default:
+            return SDImageFormatUndefined;
+    }
+}
+
 @implementation YYImage (SDAdditions)
 
 #pragma mark - SDAnimatedImage
@@ -80,21 +98,7 @@
 }
 
 - (SDImageFormat)sd_imageFormat {
-    switch (self.animatedImageType) {
-        case YYImageTypeJPEG:
-        case YYImageTypeJPEG2000:
-            return SDImageFormatJPEG;
-        case YYImageTypePNG:
-            return SDImageFormatPNG;
-        case YYImageTypeGIF:
-            return SDImageFormatGIF;
-        case YYImageTypeTIFF:
-            return SDImageFormatTIFF;
-        case YYImageTypeWebP:
-            return SDImageFormatWebP;
-        default:
-            return SDImageFormatUndefined;
-    }
+    return SDImageFormatFromYYImageType(self.animatedImageType);
 }
 
 - (void)setSd_imageFormat:(SDImageFormat)sd_imageFormat {


### PR DESCRIPTION
This PR changes many different behavior from 5.10.0 ~ 5.15.0 because of SDImageCache's changes


And this plugin will be deprecated in the future because of maintainess is really hard (SDImageCache contains many decoding/async/sync logic which is hard to match up with...)